### PR TITLE
add documentation to open mednafen directly

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/README.md
+++ b/README.md
@@ -19,3 +19,17 @@ Once installed, you can open it through your system's application manager or fro
 ```bash
 flatpak run com.github.AmatCoder.mednaffe
 ```
+
+## Open included Mednafen emulator directly
+
+You can open the Mednafen emulator directly from the terminal with this command:
+
+```bash
+flatpak run --command=mednafen com.github.AmatCoder.mednaffe [FILE]
+```
+
+Use this command to get the valid option parameters and their usage:
+
+```bash
+flatpak run --command=mednafen com.github.AmatCoder.mednaffe -help
+```


### PR DESCRIPTION
Hello together,

thank you for distributing Mednaffe and Mednafen via flathub :)

I searched for a way to open mednafen on my Steam Deck. After a long search i found out, that mednafen is already included in this flatpak, but for me it wasn't clear in the beginning how to use it. Therefore i created this pull request to make it more clear.

I hope it suits you well. If not please let me know.

Thanks in regards